### PR TITLE
fix location #hash auto-open  in modern browsers

### DIFF
--- a/wadl_documentation-2009-02.xsl
+++ b/wadl_documentation-2009-02.xsl
@@ -286,6 +286,13 @@
                         opacity: 0.75;
                     }
                 </style>
+                <script type="text/javascript">
+                    window.onload = function() {
+                        if (location.hash){
+                            location = location.hash;
+                        }
+                    }
+                </script>                
             </head>
             <body>
                 <h1>


### PR DESCRIPTION
Hi!

Modern browsers do not auto-open  url#hash 